### PR TITLE
尝试支持可爱猫5.4+的图片和视频发送

### DIFF
--- a/CuteCat/__init__.py
+++ b/CuteCat/__init__.py
@@ -72,7 +72,7 @@ class CuteCat(SyncApi):
 
     def url_preprocess(self , msg : str):
         path = msg['msg']
-        if '\\WeChat' in path:
+        if ('\\WeChat' in path) or ('\\Applet' in path):
             return f"{self.api_url}/get_file?path={path}"
         else:
             return path


### PR DESCRIPTION
由于可爱猫5.4+修改了默认图片保存的位置为C:\Users\Administrator\Documents\Applet\static，所以此处增加\\Applet用于判断视频和图片连接用于传输。但对于文件的接收，仍然出现问题是：
"msg":"C:\\Cat\\file\\WeChat Files\\wxid\\FileStorage\\File\\2022-07\\关于公布2022年AAAA.doc"
会直接向tg发送此条消息，并没有进行文件传输。